### PR TITLE
ci: Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
           bundler-cache: true
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
@@ -45,7 +45,7 @@ jobs:
       
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       
       - name: Build Storybook
         run: |
@@ -72,14 +72,14 @@ jobs:
           ls -la _site/storybook/
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '_site'
       
       - name: Deploy to GitHub Pages
         id: deployment
         if: github.ref == 'refs/heads/main'
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updates GitHub Actions workflow to use latest versions:
- actions/checkout@v4
- actions/setup-node@v4
- actions/configure-pages@v4
- actions/upload-pages-artifact@v3
- actions/deploy-pages@v4

This fixes the deprecated action version error and should enable proper GitHub Pages deployment.