### PR TITLE
ci: Fix bundle platform compatibility issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ jobs:
           ruby-version: '3.3.0'
           bundler-cache: true
       
+      - name: Update bundle platforms
+        run: |
+          bundle lock --add-platform x86_64-linux
+          bundle lock --add-platform ruby
+          
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -38,10 +43,9 @@ jobs:
       
       - name: Install dependencies
         run: |
+          bundle config set --local deployment true
+          bundle install --jobs 4
           npm ci
-          bundle install
-        env:
-          BUNDLE_DEPLOYMENT: true
       
       - name: Setup Pages
         id: pages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,12 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.1-x64-mingw-ucrt)
+    ffi (1.17.1-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.30.0-x64-mingw-ucrt)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.0-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -63,6 +67,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.85.1-x64-mingw-ucrt)
       google-protobuf (~> 4.29)
+    sass-embedded (1.85.1-x86_64-linux-gnu)
+      google-protobuf (~> 4.29)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -74,6 +80,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)


### PR DESCRIPTION
Fixes bundle platform compatibility issues:
- Adds x86_64-linux platform to bundle lockfile
- Updates workflow to handle platform-specific dependencies
- Improves Ruby setup in GitHub Actions
- Adds explicit bundle configuration

This should resolve the bundle install errors in the deployment workflow.