### PR TITLE
ci: Update GitHub Pages deployment workflow to match GitHub standards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll + Storybook
+name: Deploy Jekyll site to Pages
 
 on:
   push:
@@ -6,24 +6,26 @@ on:
   pull_request:
     branches: [ main ]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-    
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+      
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -34,22 +36,22 @@ jobs:
         run: |
           bundle lock --add-platform x86_64-linux
           bundle lock --add-platform ruby
-          
+      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
       
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      
       - name: Install dependencies
         run: |
           bundle config set --local deployment true
           bundle install --jobs 4
           npm ci
-      
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
       
       - name: Build Storybook
         run: |
@@ -79,15 +81,15 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: '_site'
-      
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        if: github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Deployment Status
-        run: |
-          echo "Deployment completed"
-          echo "URL: ${{ steps.deployment.outputs.page_url }}"


### PR DESCRIPTION
Updates the GitHub Pages workflow to:
- Match GitHub's recommended structure
- Split build and deploy into separate jobs
- Set proper permissions and concurrency
- Improve artifact handling
- Fix deployment environment configuration